### PR TITLE
registration form, not linked yet

### DIFF
--- a/data/qualification_centers.yml
+++ b/data/qualification_centers.yml
@@ -1,0 +1,22 @@
+- 
+  city: Antwerpen
+- 
+  city: Bruxelles / Brussel
+- 
+  city: Gent
+- 
+  city: Hasselt
+- 
+  city: Kortrijk
+- 
+  city: Leuven
+- 
+  city: Libramont
+- 
+  city: Liège
+- 
+  city: Louvain-la-Neuve
+- 
+  city: Mons
+- 
+  city: Namur

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -130,3 +130,37 @@ fr:
   # Archives
   previous_olympiad_edition_tile: beOI %d
 
+  # Registrations
+  registration_title: Inscription à la beOI %s
+  email_field: Adresse e-mail
+  firstname_field: Prénom
+  lastname_field: Nom de famille
+  birthday_field: Date de naissance
+  gender_field: Sexe
+  gender_men: Masculin
+  gender_women: Féminin
+  city_field: Ville
+  city_placeholder: Ville (+ pays si pas Belgique)
+  school_field: École
+  school_name_placeholder: Nom de l'école
+  school_city_placeholder: Ville de l'école
+  school_year_field: Classe
+  select_make_choice: Sélectionnez une valeur
+  primary: primaire
+  secondary: secondaire
+  year_1st: 1re
+  year_2nd: 2e
+  year_3rd: 3e
+  year_4th: 4e
+  year_5th: 5e
+  year_6th: 6e
+  year_7th: 7e
+  qualification_center_field: Centre pour l'éliminatoire
+  qualification_center_my_school: mon école
+  qualification_center_my_school_expl: |
+    Si vous choississez "%s", votre école DOIT nous contacter et
+    suivre les règles définies dans la %s.
+  registration_rule_approval: |
+    En vous inscrivant, vous acceptez les règles du concours décrites dans
+    la page %s.
+  subscribe_button: M'inscrire

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -141,8 +141,9 @@ fr:
   gender_women: Féminin
   city_field: Ville
   city_placeholder: Ville (+ pays si pas Belgique)
-  school_field: École
+  school_field: "École (nom, code postal et ville)"
   school_name_placeholder: Nom de l'école
+  school_zip_placeholder: CP
   school_city_placeholder: Ville de l'école
   school_year_field: Classe
   select_make_choice: Sélectionnez une valeur

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -137,8 +137,9 @@ nl:
   gender_women: Vrouwelijk
   city_field: Gemeente
   city_placeholder: Gemeente (+ land indien niet in België) 
-  school_field: School
+  school_field: "School (naam, postcode en gemeente)"
   school_name_placeholder: Naam van de school
+  school_zip_placeholder: Postcode
   school_city_placeholder: Stad van de school
   school_year_field: Klas
   select_make_choice: Selecteer een waarde

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -126,3 +126,35 @@ nl:
   # Archives
   previous_olympiad_edition_tile: beOI %d
   
+   # Registrations
+  registration_title: Inschrijven voor beOI %s
+  email_field: E-mailadres
+  firstname_field: Voornaam
+  lastname_field: Achternaam
+  birthday_field: Geboortedatum
+  gender_field: Geslacht
+  gender_men: Mannelijk
+  gender_women: Vrouwelijk
+  city_field: Gemeente
+  city_placeholder: Gemeente (+ land indien niet in België) 
+  school_field: School
+  school_name_placeholder: Naam van de school
+  school_city_placeholder: Stad van de school
+  school_year_field: Klas
+  select_make_choice: Selecteer een waarde
+  primary: lagere school
+  secondary: middelbaar
+  year_1st: 1e
+  year_2nd: 2e
+  year_3rd: 3e
+  year_4th: 4e
+  year_5th: 5e
+  year_6th: 6e
+  year_7th: 7e
+  qualification_center_field: Centrum voor eerste ronde
+  qualification_center_my_school: mijn school
+  qualification_center_my_school_expl: |
+    Als je kiest voor "%s", dan MOET jouw school ons contacteren en de regels volgen die in de %s staan.
+  registration_rule_approval: |
+    Door je in te schrijven aanvaard je de regels van de wedstrijd beschreven in het %s.
+  subscribe_button: Inschrijven

--- a/source/css/custom.css
+++ b/source/css/custom.css
@@ -70,3 +70,60 @@ ul[data-bullet] li {
   80% { opacity: 0; }
   100% { opacity: 0; }
 }
+
+/* form */
+.mc-field-group {
+  text-align: left;
+  margin-top: 12px;
+}
+.mc-field-group input,
+.mc-field-group select {
+  margin-bottom: 0px;
+  color: #555;
+}
+.mc-field-group label{
+  font-family: "Raleway", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 11px;
+  text-transform: uppercase;
+  color: white;
+  letter-spacing: 1px;
+  font-weight: 700;
+  display: block;
+  cursor: default;
+  margin-bottom: 4px;
+}
+input[type="email"] {
+  background: #f5f5f5;
+  border: none;
+  width: 100%;
+  height: 50px;
+  padding-left: 20px;
+  font-weight: 500;
+  margin-bottom: 4px;
+  border-radius: 0;
+  color: #555;
+}
+.mce_inline_error {
+  color: white;
+  padding-bottom: 0px;
+}
+.datefield {
+  color: white;
+}
+.datefield .dayfield input,
+.datefield .monthfield input {
+  width: 20%;
+}
+.datefield .yearfield input {
+  width: 40%;
+}
+#mce-error-response,
+#mce-success-response{
+  color: white;
+  font-weight: bold;
+  background-color: rgba(255,255,255,0.2);
+  padding: 8px;
+  margin: 16px 0 8px 0;
+  border: 1px solid white;
+}
+

--- a/source/localizable/registration.html.erb
+++ b/source/localizable/registration.html.erb
@@ -11,7 +11,7 @@ mailchimp_registration_submit:
     <div class="row mt16">
       <div class="col-sm-6 col-sm-offset-3">
         <div class="feature bordered text-center">
-          <h4 class="uppercase"><%= t(:registration_title)%2015 %></h4>
+          <h4 class="uppercase"><%= t(:registration_title)%2016 %></h4>
 
           <!-- Begin MailChimp Signup Form -->
           <link href="//cdn-images.mailchimp.com/embedcode/classic-081711.css" rel="stylesheet" type="text/css">

--- a/source/localizable/registration.html.erb
+++ b/source/localizable/registration.html.erb
@@ -61,7 +61,8 @@ mailchimp_registration_submit:
           <div class="mc-field-group">
             <label for="mce-SCHNAME"><%= t(:school_field) %></label>
             <input type="text" value="" name="SCHNAME" class="required" id="mce-SCHNAME" placeholder="<%= t(:school_name_placeholder) %>">
-            <input type="text" value="" name="SCHCITY" class="required" id="mce-SCHCITY" placeholder="<%= t(:school_city_placeholder) %>">
+            <input type="text" value="" name="SCHZIP" class="required" id="mce-SCHZIP" placeholder="<%= t(:school_zip_placeholder) %>" style="width:20%;">
+            <input type="text" value="" name="SCHCITY" class="required" id="mce-SCHCITY" placeholder="<%= t(:school_city_placeholder) %>"  style="width:75%;">
           </div>
           <div class="mc-field-group">
             <label for="mce-YEAR"><%= t(:school_year_field) %>

--- a/source/localizable/registration.html.erb
+++ b/source/localizable/registration.html.erb
@@ -1,0 +1,119 @@
+---
+title: Registration
+mailchimp_registration_submit:
+  fr: "//be-oi.us6.list-manage.com/subscribe/post?u=4a51a9ab354aa26ba87f9a75f&amp;id=7625cd0208"
+  nl: "//be-oi.us9.list-manage.com/subscribe/post?u=c6d8dcea8c4875082e570aee9&amp;id=7047097aa7"
+---
+<section class="cover image-bg overlay">
+  <div class="background-image-holder" id="page-header-image-holder">
+  </div>
+  <div class="container">
+    <div class="row mt16">
+      <div class="col-sm-6 col-sm-offset-3">
+        <div class="feature bordered text-center">
+          <h4 class="uppercase"><%= t(:registration_title)%2015 %></h4>
+
+          <!-- Begin MailChimp Signup Form -->
+          <link href="//cdn-images.mailchimp.com/embedcode/classic-081711.css" rel="stylesheet" type="text/css">
+          <style type="text/css">
+            #mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+            /* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
+            We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+          </style>
+          <form action="<%= current_page.data.mailchimp_registration_submit[lang] %>" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+
+            <div class="mc-field-group">
+              <label for="mce-EMAIL"><%= t(:email_field) %>
+              </label>
+              <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+            </div>
+            <div class="mc-field-group">
+              <label for="mce-FNAME"><%= t(:firstname_field) %>
+              </label>
+              <input type="text" value="" name="FNAME" class="required" id="mce-FNAME">
+            </div>
+            <div class="mc-field-group">
+              <label for="mce-LNAME"><%= t(:lastname_field) %>
+              </label>
+              <input type="text" value="" name="LNAME" class="required" id="mce-LNAME">
+            </div>
+            <div class="mc-field-group size1of2">
+              <label for="mce-BIRTHD-month"><%= t(:birthday_field) %>
+              </label>
+              <div class="datefield">
+                <span class="subfield dayfield"><input class="datepart required" type="text" pattern="[0-9]*" value="" placeholder="DD" size="2" maxlength="2" name="BIRTHD[day]" id="mce-BIRTHD-day"></span> / 
+                <span class="subfield monthfield"><input class="datepart required" type="text" pattern="[0-9]*" value="" placeholder="MM" size="2" maxlength="2" name="BIRTHD[month]" id="mce-BIRTHD-month"></span> / 
+                <span class="subfield yearfield"><input class="datepart required" type="text" pattern="[0-9]*" value="" placeholder="YYYY" size="4" maxlength="4" name="BIRTHD[year]" id="mce-BIRTHD-year"></span>
+              </div>
+            </div><div class="mc-field-group">
+            <label for="mce-GENDER"><%= t(:gender_field) %>
+            </label>
+            <select name="GENDER" class="required" id="mce-GENDER">
+              <option value="Male" selected="selected"><%= t(:gender_men) %></option>
+              <option value="Female"><%= t(:gender_women) %></option>
+            </select>
+          </div>
+          <div class="mc-field-group">
+            <label for="mce-CITY"><%= t(:city_field) %>
+            </label>
+            <input type="text" value="" name="CITY" class="required" id="mce-CITY" placeholder="<%= t(:city_placeholder) %>">
+          </div>
+          <div class="mc-field-group">
+            <label for="mce-SCHNAME"><%= t(:school_field) %></label>
+            <input type="text" value="" name="SCHNAME" class="required" id="mce-SCHNAME" placeholder="<%= t(:school_name_placeholder) %>">
+            <input type="text" value="" name="SCHCITY" class="required" id="mce-SCHCITY" placeholder="<%= t(:school_city_placeholder) %>">
+          </div>
+          <div class="mc-field-group">
+            <label for="mce-YEAR"><%= t(:school_year_field) %>
+            </label>
+            <select name="YEAR" class="required" id="mce-YEAR">
+              <option value=""><%= t(:select_make_choice) %></option>
+              <option value="prim"><%= "#{t(:primary)} (#{t(:Cadet)})" %></option>
+              <option value="1sec"><%= "#{t(:year_1st)} #{t(:secondary)} (#{t(:Cadet)})" %></option>
+              <option value="2sec"><%= "#{t(:year_2nd)} #{t(:secondary)} (#{t(:Cadet)})" %></option>
+              <option value="3sec"><%= "#{t(:year_3rd)} #{t(:secondary)} (#{t(:Junior)})" %></option>
+              <option value="4sec"><%= "#{t(:year_4th)} #{t(:secondary)} (#{t(:Junior)})" %></option>
+              <option value="5sec"><%= "#{t(:year_5th)} #{t(:secondary)} (#{t(:Senior)})" %></option>
+              <option value="6sec"><%= "#{t(:year_6th)} #{t(:secondary)} (#{t(:Senior)})" %></option>
+              <option value="7sec"><%= "#{t(:year_7th)} #{t(:secondary)} (#{t(:Senior)})" %></option>
+            </select>
+          </div>
+          <div class="mc-field-group">
+            <label for="mce-CENTER"><%= t(:qualification_center_field) %>
+            </label>
+            <select name="CENTER" class="required" id="mce-CENTER">
+              <option value=""><%= t(:select_make_choice) %></option>
+              <% data.qualification_centers.each do |c| %>
+              <option value="<%= c.city %>"><%= c.city %></option>
+              <% end %>
+              <option value="In my school"><%= t(:qualification_center_my_school) %></option>
+            </select>
+            <span><%= t(:qualification_center_my_school_expl)%[t(:qualification_center_my_school),link_to(t(:FAQ),"faq")] %></span>
+          </div>
+          <div id="mce-responses" class="clear">
+            <div class="response" id="mce-error-response" style="display:none"></div>
+            <div class="response" id="mce-success-response" style="display:none"></div>
+          </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+          <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_4a51a9ab354aa26ba87f9a75f_7625cd0208" tabindex="-1" value=""></div>
+          <input type="submit" value="<%= t(:subscribe_button) %>" name="subscribe" id="mc-embedded-subscribe-nocss" class="button mt24">
+        </form>
+
+        <script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='BIRTHD';ftypes[3]='date';fnames[4]='GENDER';ftypes[4]='dropdown';fnames[5]='CITY';ftypes[5]='text';fnames[6]='SCHNAME';ftypes[6]='text';fnames[7]='SCHCITY';ftypes[7]='text';fnames[8]='YEAR';ftypes[8]='dropdown';fnames[9]='CENTER';ftypes[9]='dropdown';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+        <!--End mc_embed_signup-->
+
+        <p class="mb0"><%= t(:registration_rule_approval)%link_to(t(:rules_title),"rules") %></p>
+      </div>
+    </div>
+  </div>
+  <!--end of row-->
+</div>
+<!--end of container-->
+</section>
+<script>
+  var pattern = Trianglify({
+    width: window.innerWidth,
+    height: window.innerHeight*6,
+    x_colors: "RdYlGn"
+  });
+  document.getElementById("page-header-image-holder").appendChild(pattern.canvas())
+</script>


### PR DESCRIPTION
to be done: translate and test it 

Registrations are now registered through Mailchimp. 
I've created the "BeOI'16 Deelnemers" list on the beoi_nl account, it stands for the Dutch-speaking  contestants. However, you need to tweak the messages sent (mails) and page displayed so that it is clear that they registered to a contest and not just to a mailing list. In practice, it is just in "Signup-forms>General forms>NAME-OF-THE-FORM>Translate it" (or Build it). 
You just need to update those who can be displayed so for "opt-in confirm email" and "confirmation thank you page" (I changed the message to "Merci pour votre inscription. Vous recevrez, quelques jours avant le concours, plus d'informations sur les aspects pratiques. ").  Try it in French with your own address to test it . 

With this pull-request, everything will be ready for opening the registrations but it will still not be available on the website (no link to this page).

You can merge when done.

