### PR TITLE
Flemish qualif centers 2019

### DIFF
--- a/data/qualification_centers.yml
+++ b/data/qualification_centers.yml
@@ -41,11 +41,10 @@
 -
   city: Hasselt
   place: Universiteit Hasselt
-  address: Te bepalen / A définir
-  # |
-  #   Lokaal Units AB LL2
-  #   Agoralaan gebouw D
-  #   3590 Diepenbeek
+  address: |
+     Lokaal B17
+     Agoralaan gebouw D
+     3590 Diepenbeek
   # route_link: https://drive.google.com/a/uhasselt.be/open?id=1zXIf7GVO8ILyyZWhAxpnhnuAHEZO80-i&usp=sharing
   pos:
     lat: 50.9253703
@@ -66,13 +65,12 @@
 -
   city: Leuven
   place: KU Leuven
-  address: Te bepalen / A définir
-  # |
-  #   Departement Computerwetenschappen
-  #   Lokaal 200A-00.124
-  #   Celestijnenlaan 200A
-  #   3001 Heverlee
-  # route_link: https://wms.cs.kuleuven.be/cs/algemeen/routebeschrijving
+  address: |
+     Departement Computerwetenschappen
+     Lokaal 200A-00.124
+     Celestijnenlaan 200A
+     3001 Heverlee
+  route_link: https://wms.cs.kuleuven.be/cs/algemeen/routebeschrijving
   pos:
     lat: 50.86411
     lng: 4.6786777

--- a/data/qualification_centers.yml
+++ b/data/qualification_centers.yml
@@ -1,13 +1,12 @@
 -
   city: Antwerpen
   place: Universiteit Antwerpen
-  address: Te bepalen / A définir
-  # |
-  #   Campus Groenenborger, gebouw Z
-  #   lokaal Z.421
-  #   Groenenborgerlaan 171
-  #   2020 Antwerpen
-  # route_link: https://www.uantwerpen.be/campus-groenenborger
+  address: |
+     Campus Groenenborger, gebouw Z
+     lokaal Z.421
+     Groenenborgerlaan 171
+     2020 Antwerpen
+  route_link: https://www.uantwerpen.be/campus-groenenborger
   pos:
     lat: 51.17821
     lng: 4.41853

--- a/data/qualification_centers.yml
+++ b/data/qualification_centers.yml
@@ -27,14 +27,15 @@
 -
   city: Gent
   place: Universiteit Gent
-  address: Te bepalen / A définir
-  # |
-  #   1e verdieping
-  #   gebouw S5
-  #   Campus Sterre
-  #   Krijgslaan 281
-  #   9000 Gent
-  # route_link: http://www.ugent.be/we/nl/diensten/ipvw-ices/contact/locaties/sterre
+  address: |
+     PC-zaal Grace Hopper
+     1e verdieping
+     gebouw S5
+     Campus Sterre
+     Krijgslaan 281
+     9000 Gent
+     (niet de campus op rijden; buiten de campus parkeren)
+  route_link: http://www.ugent.be/we/nl/diensten/ipvw-ices/contact/locaties/sterre
   pos:
     lat: 51.0227516
     lng: 3.7105733


### PR DESCRIPTION
Only VIVES Kortrijk is still missing.