### PR TITLE
add alt link to register to mailing list when the form is blocked

### DIFF
--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -131,6 +131,8 @@ fr:
   mailinglist_error_msg: Veuillez entrez une adresse e-mail correcte.
   mailinglist_email_placeholder: Adresse e-mail
   mailinglist_submit_button: Tenez-moi informé
+  mailinglist_alt_link_l1: Le formulaire ci-dessus ne fonctionne pas dans votre navigateur ?
+  mailinglist_alt_link_l2: Indiquez votre adresse email sur cette page.
 
   wait_for_qualif_results_title: Vous avez participé à l'éliminatoire ?
   wait_for_qualif_results_descr: Vos résultats vous seront transmis par e-mail dans les prochains jours.

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -131,6 +131,8 @@ nl:
   mailinglist_error_msg: Gelieve een correct e-mailadres in te geven.
   mailinglist_email_placeholder: E-mailadres
   mailinglist_submit_button: Hou me op de hoogte
+  mailinglist_alt_link_l1: Het formulier hierboven werkt niet in uw browser ?
+  mailinglist_alt_link_l2: Geef uw e-mailadres op op deze pagina.
 
   wait_for_qualif_results_title: Heb je deelgenomen aan de eerste ronde ?
   wait_for_qualif_results_descr: Je krijgt jouw resultaten via email in de loop van de volgende dagen.

--- a/source/localizable/_index_action_block.html.erb
+++ b/source/localizable/_index_action_block.html.erb
@@ -9,6 +9,10 @@
           when :preregistration %>
           <h2 class="large text-center"><%= t("keep_me_informed_of_registrations") %></h2>
           <div class="row mb24"><%= partial "subscribe_info_form" %></div>
+          <div class="row mb24">
+            <span class="thin" style="color:#ccc;"><%= t("mailinglist_alt_link_l1") %></span>
+            <a class="thin" href="<%= current_page.data.mailchimp_alt[lang] %>" target="_blank"><%= t("mailinglist_alt_link_l2") %></a>
+          </div>
 
           <% when :registration %>
           <h2 class="large"><%= t("register_text") %></h2>

--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -4,6 +4,7 @@ mailchimp_submit:
   nl: "//be-oi.us9.list-manage.com/subscribe/post?u=c6d8dcea8c4875082e570aee9&amp;id=96b626466f"
 mailchimp_alt:
   fr: http://eepurl.com/bpfE3v
+  nl: http://eepurl.com/cG8Etf
 contest_platform:
   fr: https://concours.be-oi.be/
   nl: https://wedstrijd.be-oi.be/

--- a/source/localizable/index.html.erb
+++ b/source/localizable/index.html.erb
@@ -2,6 +2,8 @@
 mailchimp_submit:
   fr: "//be-oi.us6.list-manage.com/subscribe/post?u=4a51a9ab354aa26ba87f9a75f&amp;id=0637c4db56"
   nl: "//be-oi.us9.list-manage.com/subscribe/post?u=c6d8dcea8c4875082e570aee9&amp;id=96b626466f"
+mailchimp_alt:
+  fr: http://eepurl.com/bpfE3v
 contest_platform:
   fr: https://concours.be-oi.be/
   nl: https://wedstrijd.be-oi.be/


### PR DESCRIPTION
I have added a link under the mailing list form in case it does not work.
@btj , could you:
* translate the 2 sentences
* get the link to the form from the mailchimp nl account ? (I cannot access it as it requires an email or sms validation). It is in "audience" > sign-up forms > Form builder 