### PR TITLE
Be oi2022 final intro messages

### DIFF
--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -246,14 +246,13 @@ fr:
 
   final_result_title: "Finale: Résultats"
   final_results_expl_past: |
-    Pas de proclamation cette année à cause de la pandémie de Coronavirus.<br>
+    La finale de l'olympiade 2022 eu lieu le 23 avril à Bruxelles.<br>
     Les classements ci-dessous reprennent, par catégorie, les résultats de la finale.<br>
-    Les premiers de chaque catégorie seront contactés par mail et recevront un diplôme par la poste.
   final_results_expl_future: |
+    La finale de l'olympiade 2022 eu lieu le 23 avril à Bruxelles.<br>
     Les classements ci-dessous reprennent, par catégorie, les résultats de la finale.<br>
     Les premiers de chaque catégorie sont donnés par ordre alphabétique et sans leur score.<br>
-    Ils recevront leur classement final et un prix lors de la proclamation prévue le 23 mai à Bruxelles.<br>
-    <strong>La proclamation sera peut-être reportée ou annulée en fonction de l'évolution de la pandémie de Coronavirus.</strong>
+    Ils recevront leur classement final et un prix lors de la proclamation prévue le 14 mai à Bruxelles.<br>
   final_top: Top-%d, par ordre alphabétique
   final_after_top: Classement après la %de position
   qualif_intro_text: |

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -244,14 +244,13 @@ nl:
 
   final_result_title: "Finale: resultaten"
   final_results_expl_past: |
-    Geen proclamatie dit jaar vanwege de pandemie van het Coronavirus.<br>
+    De finale van de olympiade 2022 vond plaats op 23 april in Brussel.<br>
     Hieronder staan, per categorie, de resultaten van de finale.<br>
-    De eerste in elke categorie wordt per e-mail gecontacteerd en ontvangt een diploma per post.
   final_results_expl_future: |
+    De finale van de olympiade 2022 vond plaats op 23 april in Brussel.<br>
     Hieronder staan, per categorie, de resultaten van de finale.<br>
     De eerste finalisten in elke categorie zijn in alfabetische volgorde vermeld, zonder hun score.<br>
-    Zij komen hun plaats te weten, en krijgen een prijs uitgereikt, op de proclamatie op 23 mei in Brussel.<br>
-    <strong>De proclamatie kan worden uitgesteld of geannuleerd afhankelijk van de evolutie van de Coronavirus-pandemie.</strong>
+    Zij komen hun plaats te weten, en krijgen een prijs uitgereikt, op de proclamatie op 14 mei in Brussel.<br>
   final_top: Top-%d, in alfabetische volgorde
   final_after_top: Eindklassement vanaf de %de plaats
   qualif_intro_text: |

--- a/source/localizable/final_results.html.erb
+++ b/source/localizable/final_results.html.erb
@@ -7,7 +7,7 @@ trianglify_colors: '"RdYlGn"'
   <div class="container">
     <div class="row">
       <div class="col-md-6">
-        <h3 class="uppercase mb0"><%= t(:final_result_title) %> 2022</h3>
+        <h3 class="uppercase mb0"><%= t(:final_result_title) %> <%= config.beoi_year %></h3>
       </div>
     </div>
     <!--end of row-->
@@ -20,8 +20,8 @@ trianglify_colors: '"RdYlGn"'
   <div class="container">
     <div class="row">
       <div class="col-sm-8 col-sm-offset-2 text-center">
-        <!-- <p class="mb16 text-center lead"><%= t(:final_results_expl_future) %></p>  -->
-        <p class="mb16 text-center lead"><%= t(:final_results_expl_past) %></p>
+        <p class="mb16 text-center lead"><%= t(:final_results_expl_future) %></p>
+        <!-- <p class="mb16 text-center lead"><%= t(:final_results_expl_past) %></p> -->
       </div>
     </div>
   </div>


### PR DESCRIPTION
Seconde branche pour publication des résultats de la finale.
Les messages d'introduction au-dessus des tableaux de résultats n'avaient pas été mis à jour.
