### PR TITLE
Wrong school name corrected for 2 contestants.

### DIFF
--- a/data/results_2022_final.yml
+++ b/data/results_2022_final.yml
@@ -422,7 +422,7 @@ contestants:
     - position: "-"
       score: 69
       name: Luca Neo De Clercq
-      school: École Européenne III
+      school: Bischöfliches Institut Büllingen
       year: year_4th
     - position: 32
       score: 68
@@ -457,7 +457,7 @@ contestants:
     - position: 38
       score: 65
       name: Luca Van Herk
-      school: Bischöfliches Institut Büllingen
+      school: TISM
       year: year_4th
     - position: "-"
       score: 65

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -246,10 +246,10 @@ fr:
 
   final_result_title: "Finale: Résultats"
   final_results_expl_past: |
-    La finale de l'olympiade 2022 eu lieu le 23 avril à Bruxelles.<br>
+    La finale de l'olympiade 2022 a eu lieu le 23 avril à Bruxelles.<br>
     Les classements ci-dessous reprennent, par catégorie, les résultats de la finale.<br>
   final_results_expl_future: |
-    La finale de l'olympiade 2022 eu lieu le 23 avril à Bruxelles.<br>
+    La finale de l'olympiade 2022 a eu lieu le 23 avril à Bruxelles.<br>
     Les classements ci-dessous reprennent, par catégorie, les résultats de la finale.<br>
     Les premiers de chaque catégorie sont donnés par ordre alphabétique et sans leur score.<br>
     Ils recevront leur classement final et un prix lors de la proclamation prévue le 14 mai à Bruxelles.<br>


### PR DESCRIPTION
Wrong school name corrected for 2 contestants.
Change "eu lieu" by "a eu lieu" in final French results head message.