### PR TITLE
Cadet rating corrected: Korneel Priem and Korneel Beyls were inverted.

### DIFF
--- a/data/results_2023_final.yml
+++ b/data/results_2023_final.yml
@@ -67,8 +67,8 @@ contestants:
       year: year_2nd
     - position: "-"
       score: 53
-      name: Korneel Beyls
-      school: GO! Atheneum Mariakerke, Mariakerke
+      name: Korneel Priem
+      school: Leiepoort campus Sint-Hendrick, Deinze
       year: year_2nd
     - position: 14
       score: 52
@@ -287,7 +287,7 @@ contestants:
       year: year_2nd
     - position: "-"
       score: 35
-      name: Korneel Priem
+      name: Korneel Beyls
       school: GO! Atheneum Mariakerke, Mariakerke
       year: year_2nd
     - position: "-"


### PR DESCRIPTION
The scores, places and schools are now correct for both.